### PR TITLE
[planning-poker] Add tests on CI

### DIFF
--- a/.github/workflows/planning-poker-ci.yml
+++ b/.github/workflows/planning-poker-ci.yml
@@ -8,16 +8,75 @@ on:
       - 'planning-poker/**'
       - '!planning-poker/version.txt'
       - '!planning-poker/frontend/**'
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - 'planning-poker/**'
+      - '!planning-poker/version.txt'
+      - '!planning-poker/frontend/**'
 
 env:
-  # Base variables
   APP_DIR: planning-poker
   DOCKER_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/planning-poker-backend
+  GO_VERSION: '1.25.4'
 
 jobs:
-  build_and_publish:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: ${{ env.APP_DIR }}/go.sum
+
+      - name: Download Dependencies
+        working-directory: ${{ env.APP_DIR }}
+        run: go mod download
+
+      - name: Verify Dependencies
+        working-directory: ${{ env.APP_DIR }}
+        run: go mod verify
+
+      - name: Run Tests
+        working-directory: ${{ env.APP_DIR }}
+        run: go test -timeout 30s -coverprofile=coverage.out ./...
+
+      - name: Generate Coverage Report
+        working-directory: ${{ env.APP_DIR }}
+        run: go tool cover -func=coverage.out
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          working-directory: ${{ env.APP_DIR }}
+          args: --timeout=5m
+
+  release:
     runs-on: ubuntu-latest
     environment: production
+    needs: 
+      - test
+      - lint
+
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     permissions:
       contents: write

--- a/.github/workflows/planning-poker-frontend-ci.yml
+++ b/.github/workflows/planning-poker-frontend-ci.yml
@@ -7,9 +7,14 @@ on:
     paths:
       - 'planning-poker/frontend/planning-poker-front/**'
       - '!planning-poker/frontend/planning-poker-front/version.txt'
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - 'planning-poker/frontend/planning-poker-front/**'
+      - '!planning-poker/frontend/planning-poker-front/version.txt'
 
 env:
-  # Base variables
   APP_DIR: planning-poker/frontend/planning-poker-front
   DOCKER_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/planning-poker-frontend
 
@@ -17,6 +22,8 @@ jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     environment: production
+
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     permissions:
       contents: write


### PR DESCRIPTION
This pull request updates the CI workflows for both the backend and frontend of the Planning Poker project to improve reliability and ensure code quality. The main changes are the addition of pull request triggers, separation of test and lint jobs, and stricter release conditions.

**Backend CI workflow improvements (`.github/workflows/planning-poker-ci.yml`):**

* Added a `pull_request` trigger for the `main` branch, ensuring CI runs on PRs and not just pushes.
* Split the workflow into separate `test`, `lint`, and `release` jobs, improving clarity and enforcing that tests and linting must pass before releasing.
* The `release` job is now restricted to run only on pushes to `main`, and only if tests and linting are successful.
* Introduced Go version management via the `GO_VERSION` environment variable for consistency.

**Frontend CI workflow improvements (`.github/workflows/planning-poker-frontend-ci.yml`):**

* Added a `pull_request` trigger for the `main` branch, so frontend CI runs on PRs as well.
* The `release` job is now restricted to run only on pushes to `main`, preventing accidental releases from PRs or other branches.