### PR TITLE
feat: [#71] simplify room entry to websocket-first flow

### DIFF
--- a/planning-poker/frontend/planning-poker-front/src/app/join/page.tsx
+++ b/planning-poker/frontend/planning-poker-front/src/app/join/page.tsx
@@ -2,54 +2,29 @@
 
 import { useToast } from '@/context/toast/toastContext';
 import { Loader2, LogIn, Plus } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { styles } from './page.styles';
 
-export default function PlanningPokerHome({ params }: { params: Promise<{ roomId: string | null }> }) {
+export default function PlanningPokerHome() {
   const router = useRouter();
+  const params = useParams<{ roomId?: string }>();
   const [roomCode, setRoomCode] = useState('');
   const [userName, setUserName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [isJoining, setIsJoining] = useState(false);
-  const myParams = React.use(params);
   const nameInputRef = React.useRef<HTMLInputElement | null>(null);
-  const hasRoomParam = Boolean(myParams?.roomId);
+  const routeRoomId = typeof params?.roomId === 'string' ? params.roomId : '';
+  const hasRoomParam = Boolean(routeRoomId);
   const { pushError } = useToast();
 
+  const getRoomRoute = (value: string) => `/room/${encodeURIComponent(value.trim())}`;
+
   useEffect(() => {
-    if (myParams.roomId) {
-      setRoomCode(myParams.roomId);
-    }
-  }, []);
+    setRoomCode(routeRoomId);
+  }, [routeRoomId]);
 
   useEffect(() => { nameInputRef.current?.focus(); }, []);
-
-  const createRoom = async (userName: string) => {
-    try {
-      setIsCreating(true);
-
-      const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/planning/room`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          createdBy: userName
-        }),
-        credentials: 'include'
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to create room');
-      }
-
-      const data = await response.json();
-      return data.roomId;
-    } finally {
-      setIsCreating(false);
-    }
-  };
 
   const handleCreateRoom = async () => {
     if (!userName.trim()) {
@@ -58,12 +33,15 @@ export default function PlanningPokerHome({ params }: { params: Promise<{ roomId
     }
 
     try {
-      const newRoomId = await createRoom(userName.trim());
+      setIsCreating(true);
+      const newRoomId = crypto.randomUUID();
       sessionStorage.setItem('userName', userName.trim());
-      router.push(`/room/${newRoomId}`);
+      router.push(getRoomRoute(newRoomId));
     } catch (err: any) {
       const message = err?.message || 'Failed to create room. Please try again.';
       pushError(message);
+    } finally {
+      setIsCreating(false);
     }
   };
 
@@ -79,27 +57,9 @@ export default function PlanningPokerHome({ params }: { params: Promise<{ roomId
     }
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/planning/room/${roomCode}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.status === 404) {
-        pushError('Room not found');
-        return
-      }
-
-      if (!response.ok) {
-        const text = await response.text();
-        const message = text || 'Failed to join room';
-        pushError(message);
-        return
-      }
-
+      setIsJoining(true);
       sessionStorage.setItem('userName', userName.trim());
-      router.push(`/room/${roomCode.trim()}`);
+      router.push(getRoomRoute(roomCode));
     } catch (err: any) {
       const message = err?.message || 'Failed to join room. Please try again.';
       pushError(message);

--- a/planning-poker/frontend/planning-poker-front/src/app/room/[roomId]/page.tsx
+++ b/planning-poker/frontend/planning-poker-front/src/app/room/[roomId]/page.tsx
@@ -14,10 +14,14 @@ import { useRoom } from '@/context/room/roomContext';
 import { useToast } from '@/context/toast/toastContext';
 import { Eye, EyeOff, Repeat, RotateCcw, Shield, Users, X } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Header from './page.header';
 import gridStyles from './page.module.css';
 import { styles } from './page.styles';
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const isValidRoomId = (value: string): boolean => uuidPattern.test(value);
 
 type Card = string | null
 
@@ -35,7 +39,9 @@ export default function PlanningPoker() {
   const router = useRouter();
   const { socket, connected } = useRoom();
   const { pushError, pushSuccess } = useToast();
-  const roomId = params?.roomId as string ?? '00000000-0000-0000-0000-000000000000';
+  const routeRoomId = typeof params?.roomId === 'string' ? params.roomId : '';
+  const [roomId, setRoomId] = useState('');
+  const connectedRoomIdRef = useRef<string | null>(null);
 
   const [selectedCard, setSelectedCard] = useState<Card>(null);
   const [userName, setUserName] = useState('');
@@ -51,6 +57,21 @@ export default function PlanningPoker() {
   const cards = ['0', '1', '2', '3', '5', '8', '13', '21', '34', '55', '89', '?', '☕'];
 
   useEffect(() => {
+    if (isValidRoomId(routeRoomId)) {
+      setRoomId(routeRoomId);
+      return;
+    }
+
+    setRoomId('');
+    pushError('Invalid room code. Redirecting to join page.');
+    router.replace('/join');
+  }, [routeRoomId, router, pushError]);
+
+  useEffect(() => {
+    if (!roomId) {
+      return;
+    }
+
     const storedUserName = sessionStorage.getItem('userName');
     if (!storedUserName) {
       router.push(`/join/${roomId}`);
@@ -58,11 +79,24 @@ export default function PlanningPoker() {
     }
     setUserName(storedUserName);
 
-    if (!connected.current) {
-      connectWebSocket(roomId, storedUserName);
-      connected.current = true;
+    const hasSameRoomConnection =
+      connected.current &&
+      connectedRoomIdRef.current === roomId &&
+      socket.current?.readyState !== WebSocket.CLOSED;
+
+    if (hasSameRoomConnection) {
+      return;
     }
-  }, [roomId]);
+
+    cleanupSocket();
+    connectWebSocket(roomId, storedUserName);
+
+    return () => {
+      if (connectedRoomIdRef.current === roomId) {
+        cleanupSocket();
+      }
+    };
+  }, [roomId, router]);
 
   useEffect(() => {
     if (clientId && participants.length > 0) {
@@ -71,7 +105,21 @@ export default function PlanningPoker() {
   }, [participants, clientId]);
 
   const sendMessage = <T,>(message: WebSocketMessage<T>) => {
-    socket.current?.send(JSON.stringify(message));
+    const activeSocket = socket.current;
+
+    if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) {
+      pushError('Connection is not ready. Please wait and try again.');
+      return;
+    }
+
+    try {
+      activeSocket.send(JSON.stringify(message));
+    } catch (err: any) {
+      const errorMessage = err?.message
+        ? `Failed to send message: ${err.message}`
+        : 'Failed to send message.';
+      pushError(errorMessage);
+    }
   }
 
   const handleCardSelect = (card: Card) => {
@@ -106,13 +154,31 @@ export default function PlanningPoker() {
     sendMessage<any>({ type: 'vote-again', payload });
   }
 
-  const connectWebSocket = async (roomCode: string | null, userName: string) => {
-    if (!roomCode) {
-      return;
-    }
-    socket.current = new WebSocket(`${process.env.NEXT_PUBLIC_WEBSOCKET_URL}/planning/${roomCode}/ws`);
+  const resetConnectionState = () => {
+    connected.current = false;
+    connectedRoomIdRef.current = null;
+    socket.current = null;
+  };
 
-    socket.current.onmessage = (event) => {
+  const cleanupSocket = () => {
+    const activeSocket = socket.current;
+    if (activeSocket) {
+      activeSocket.onopen = null;
+      activeSocket.onmessage = null;
+      activeSocket.onclose = null;
+      activeSocket.onerror = null;
+      activeSocket.close();
+    }
+    resetConnectionState();
+  };
+
+  const connectWebSocket = (roomCode: string, userName: string) => {
+    const ws = new WebSocket(`${process.env.NEXT_PUBLIC_WEBSOCKET_URL}/planning/${roomCode}/ws`);
+    socket.current = ws;
+    connected.current = true;
+    connectedRoomIdRef.current = roomCode;
+
+    ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
 
@@ -138,16 +204,23 @@ export default function PlanningPoker() {
       }
     };
 
-    socket.current.onopen = () => {
+    ws.onopen = () => {
       pushSuccess('Connected');
     };
 
-    socket.current.onclose = () => {
+    ws.onclose = () => {
       pushError('Disconnected');
+      if (socket.current === ws) {
+        resetConnectionState();
+      }
     };
 
-    socket.current.onerror = () => {
+    ws.onerror = () => {
       pushError('Error occurred while connecting to websocket');
+      if (socket.current === ws) {
+        connected.current = false;
+        connectedRoomIdRef.current = null;
+      }
     };
   };
 
@@ -170,8 +243,7 @@ export default function PlanningPoker() {
   };
 
   const handleBackToHome = () => {
-    socket.current?.close();
-    connected.current = false;
+    cleanupSocket();
     router.push('/');
   };
 


### PR DESCRIPTION
## Summary
- Simplified frontend room entry to a websocket-first flow by removing pre-connect HTTP room create/check calls from the join page.
- Kept room creation explicit in the UI: Create Room now generates a UUID client-side and routes directly to /room/{roomId}.
- Made room connection behavior more robust and deterministic:
  - invalid /room/{roomId} now redirects to /join with an error (no random fallback on join intent),
  - websocket lifecycle now cleans up/reconnects correctly when switching rooms,
  - outbound websocket sends are guarded to avoid InvalidStateError when socket is not open.

## Why
Backend now supports creating non-existent rooms on websocket connection.  
So frontend no longer needs a two-step flow (HTTP create/check before connect), reducing latency and removing redundant API dependency in the join path.

## Files Changed
- frontend/planning-poker-front/src/app/join/page.tsx
- frontend/planning-poker-front/src/app/room/[roomId]/page.tsx

## Behavioral Changes
- Join existing room: stores username and navigates directly to /room/{roomId}.
- Create room: generates UUID on click and navigates directly to /room/{uuid}.
- Room page invalid ID: shows error and redirects to /join.
- Room switching: previous socket is cleaned up before reconnecting to new room.
- Send actions: safely no-op with user feedback if websocket is not ready.

## Validation
- Frontend automated tests were intentionally deferred for this iteration.
- npm run build is currently blocked by an existing repository issue unrelated to this change:
  - Cannot find module 'vitest/config' (from vitest.config.ts).