### PR TITLE
feat: add GET /admin/rooms/{roomID} endpoint for single room state

### DIFF
--- a/planning-poker/internal/infra/boundaries/http/getallroomsstate.go
+++ b/planning-poker/internal/infra/boundaries/http/getallroomsstate.go
@@ -10,7 +10,7 @@ import (
 )
 
 type (
-	GetAllRoomsStateResponse struct {
+	GetRoomStateResponse struct {
 		ID      string                   `json:"id"`
 		Clients []GetAllRoomsStateClient `json:"clients"`
 	}
@@ -33,7 +33,7 @@ var _ API = (*GetAllRoomsStateAPI)(nil)
 // @Description Returns the state of all rooms (admin only)
 // @Tags admin
 // @Produce json
-// @Success 200 {array} GetAllRoomsStateResponse
+// @Success 200 {array} GetRoomStateResponse
 // @Failure 401 {object} ErrorResponse
 // @Security ApiKeyAuth
 // @Router /admin/rooms [get]
@@ -66,10 +66,10 @@ func (api GetAllRoomsStateAPI) execute() http.Handler {
 	})
 }
 
-func mapRooms(rooms []*entity.Room) []GetAllRoomsStateResponse {
-	res := make([]GetAllRoomsStateResponse, len(rooms))
+func mapRooms(rooms []*entity.Room) []GetRoomStateResponse {
+	res := make([]GetRoomStateResponse, len(rooms))
 	for i, room := range rooms {
-		r := GetAllRoomsStateResponse{
+		r := GetRoomStateResponse{
 			ID:      room.ID,
 			Clients: mapClients(room.Clients),
 		}

--- a/planning-poker/internal/infra/boundaries/http/getallroomsstate_test.go
+++ b/planning-poker/internal/infra/boundaries/http/getallroomsstate_test.go
@@ -88,7 +88,7 @@ func TestGetAllRoomsStateAPI_Handle_Success(t *testing.T) {
 		t.Errorf("status code = %v, want %v", rec.Code, http.StatusOK)
 	}
 
-	var response []GetAllRoomsStateResponse
+	var response []GetRoomStateResponse
 	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestGetAllRoomsStateAPI_Handle_EmptyRooms(t *testing.T) {
 		t.Errorf("status code = %v, want %v", rec.Code, http.StatusOK)
 	}
 
-	var response []GetAllRoomsStateResponse
+	var response []GetRoomStateResponse
 	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}

--- a/planning-poker/internal/infra/boundaries/http/getroomstate.go
+++ b/planning-poker/internal/infra/boundaries/http/getroomstate.go
@@ -1,0 +1,83 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"planning-poker/internal/domain"
+	"planning-poker/internal/domain/entity"
+	"planning-poker/internal/infra/boundaries/http/middleware"
+
+	"github.com/bruno303/go-toolkit/pkg/log"
+	"github.com/gorilla/mux"
+)
+
+type GetRoomStateAPI struct {
+	hub                 domain.Hub
+	adminAuthMiddleware middleware.AdminMiddleware
+	logger              log.Logger
+}
+
+var _ API = (*GetRoomStateAPI)(nil)
+
+// @Summary Get room state
+// @Description Returns the state of a specific room (admin only)
+// @Tags admin
+// @Produce json
+// @Param roomID path string true "Room ID"
+// @Success 200 {object} GetRoomStateResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Security ApiKeyAuth
+// @Router /admin/rooms/{roomID} [get]
+func NewGetRoomStateAPI(hub domain.Hub, adminAuthMiddleware middleware.AdminMiddleware) GetRoomStateAPI {
+	return GetRoomStateAPI{
+		hub:                 hub,
+		adminAuthMiddleware: adminAuthMiddleware,
+		logger:              log.NewLogger("getroomstateapi"),
+	}
+}
+
+func (api GetRoomStateAPI) Endpoint() string {
+	return "/admin/rooms/{roomID}"
+}
+
+func (api GetRoomStateAPI) Methods() []string {
+	return []string{"GET"}
+}
+
+func (api GetRoomStateAPI) Handle() http.Handler {
+	return api.adminAuthMiddleware.Handle(api.execute())
+}
+
+func (api GetRoomStateAPI) execute() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		roomID := mux.Vars(r)["roomID"]
+		if roomID == "" {
+			SendJsonErrorMsg(w, http.StatusBadRequest, "Room ID is required")
+			return
+		}
+
+		room, err := api.hub.LoadRoom(ctx, roomID)
+		if errors.Is(err, domain.ErrRoomNotFound) {
+			SendJsonErrorMsg(w, http.StatusNotFound, "Room not found")
+			return
+		}
+		if err != nil {
+			api.logger.Error(ctx, "Failed to load room", err)
+			SendJsonErrorMsg(w, http.StatusInternalServerError, "Failed to load room")
+			return
+		}
+
+		SendJsonResponse(w, http.StatusOK, mapRoom(room))
+	})
+}
+
+func mapRoom(room *entity.Room) GetRoomStateResponse {
+	return GetRoomStateResponse{
+		ID:      room.ID,
+		Clients: mapClients(room.Clients),
+	}
+}

--- a/planning-poker/internal/infra/boundaries/http/getroomstate_test.go
+++ b/planning-poker/internal/infra/boundaries/http/getroomstate_test.go
@@ -1,0 +1,269 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"planning-poker/internal/domain"
+	"planning-poker/internal/domain/entity"
+	"planning-poker/internal/infra/boundaries/http/middleware"
+	"planning-poker/internal/infra/boundaries/hub/clientcollection"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetRoomStateAPI_Endpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("test-api-key"))
+
+	if api.Endpoint() != "/admin/rooms/{roomID}" {
+		t.Errorf("Endpoint() = %v, want %v", api.Endpoint(), "/admin/rooms/{roomID}")
+	}
+}
+
+func TestGetRoomStateAPI_Methods(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("test-api-key"))
+	methods := api.Methods()
+
+	if len(methods) != 1 {
+		t.Fatalf("Methods() length = %v, want %v", len(methods), 1)
+	}
+	if methods[0] != "GET" {
+		t.Errorf("Methods()[0] = %v, want %v", methods[0], "GET")
+	}
+}
+
+func TestGetRoomStateAPI_Handle_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	apiKey := "valid-api-key"
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware(apiKey))
+
+	client1 := &entity.Client{
+		ID:          "client1",
+		Name:        "Alice",
+		IsSpectator: false,
+		IsOwner:     true,
+	}
+	client2 := &entity.Client{
+		ID:          "client2",
+		Name:        "Bob",
+		IsSpectator: true,
+		IsOwner:     false,
+	}
+
+	roomID := "room1"
+	mockHub.EXPECT().
+		LoadRoom(gomock.Any(), roomID).
+		Return(&entity.Room{ID: roomID, Clients: clientcollection.New(client1, client2)}, nil)
+
+	handler := api.Handle()
+	router := mux.NewRouter()
+	router.Handle("/admin/rooms/{roomID}", handler).Methods("GET")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/room1", nil)
+	req.Header.Set("Authorization", "Bearer valid-api-key")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %v, want %v", rec.Code, http.StatusOK)
+	}
+
+	var response GetRoomStateResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.ID != roomID {
+		t.Errorf("response.ID = %v, want %v", response.ID, roomID)
+	}
+	if len(response.Clients) != 2 {
+		t.Fatalf("response.Clients length = %v, want %v", len(response.Clients), 2)
+	}
+	if response.Clients[0].ID != "client1" || response.Clients[0].Name != "Alice" || response.Clients[0].IsSpectator || !response.Clients[0].IsOwner {
+		t.Errorf("response.Clients[0] = %+v, want client1/Alice/false/true", response.Clients[0])
+	}
+	if response.Clients[1].ID != "client2" || response.Clients[1].Name != "Bob" || !response.Clients[1].IsSpectator || response.Clients[1].IsOwner {
+		t.Errorf("response.Clients[1] = %+v, want client2/Bob/true/false", response.Clients[1])
+	}
+}
+
+func TestGetRoomStateAPI_Handle_RoomNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("valid-api-key"))
+
+	roomID := "nonexistent"
+	mockHub.EXPECT().
+		LoadRoom(gomock.Any(), roomID).
+		Return(nil, domain.ErrRoomNotFound)
+
+	handler := api.Handle()
+	router := mux.NewRouter()
+	router.Handle("/admin/rooms/{roomID}", handler).Methods("GET")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/nonexistent", nil)
+	req.Header.Set("Authorization", "Bearer valid-api-key")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status code = %v, want %v", rec.Code, http.StatusNotFound)
+	}
+
+	var errorResponse map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&errorResponse); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+
+	if errorResponse["error"] != "Room not found" {
+		t.Errorf("error message = %v, want %v", errorResponse["error"], "Room not found")
+	}
+}
+
+func TestGetRoomStateAPI_Handle_Unauthorized(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("valid-api-key"))
+
+	handler := api.Handle()
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/room123", nil)
+	req.Header.Set("Authorization", "Bearer wrong-api-key")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status code = %v, want %v", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetRoomStateAPI_Handle_MissingAuthHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("valid-api-key"))
+
+	handler := api.Handle()
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/room123", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status code = %v, want %v", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetRoomStateAPI_Handle_MissingRoomID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("valid-api-key"))
+
+	handler := api.Handle()
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/", nil)
+	req.Header.Set("Authorization", "Bearer valid-api-key")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status code = %v, want %v", rec.Code, http.StatusBadRequest)
+	}
+
+	var errorResponse map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&errorResponse); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+
+	if errorResponse["error"] != "Room ID is required" {
+		t.Errorf("error message = %v, want %v", errorResponse["error"], "Room ID is required")
+	}
+}
+
+func TestGetRoomStateAPI_Handle_LoadRoomError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("valid-api-key"))
+
+	mockHub.EXPECT().
+		LoadRoom(gomock.Any(), "room123").
+		Return(nil, context.DeadlineExceeded)
+
+	handler := api.Handle()
+	router := mux.NewRouter()
+	router.Handle("/admin/rooms/{roomID}", handler).Methods("GET")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/room123", nil)
+	req.Header.Set("Authorization", "Bearer valid-api-key")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status code = %v, want %v", rec.Code, http.StatusInternalServerError)
+	}
+
+	var errorResponse map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&errorResponse); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+
+	if errorResponse["error"] != "Failed to load room" {
+		t.Errorf("error message = %v, want %v", errorResponse["error"], "Failed to load room")
+	}
+}
+
+func TestGetRoomStateAPI_Handle_ContextPropagation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHub := domain.NewMockHub(ctrl)
+	api := NewGetRoomStateAPI(mockHub, middleware.NewAdminMiddleware("valid-api-key"))
+
+	var capturedCtx context.Context
+	mockHub.EXPECT().
+		LoadRoom(gomock.Any(), "room123").
+		DoAndReturn(func(ctx context.Context, roomID string) (*entity.Room, error) {
+			capturedCtx = ctx
+			return &entity.Room{ID: roomID, Clients: clientcollection.New()}, nil
+		})
+
+	handler := api.Handle()
+	router := mux.NewRouter()
+	router.Handle("/admin/rooms/{roomID}", handler).Methods("GET")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/rooms/room123", nil)
+	req.Header.Set("Authorization", "Bearer valid-api-key")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if capturedCtx == nil {
+		t.Error("context was not propagated to hub")
+	}
+}

--- a/planning-poker/internal/infra/boundaries/http/swagger/swagger.json
+++ b/planning-poker/internal/infra/boundaries/http/swagger/swagger.json
@@ -30,12 +30,70 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/http.GetAllRoomsStateResponse"
+                                "$ref": "#/definitions/http.GetRoomStateResponse"
                             }
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/rooms/{roomID}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the state of a specific room (admin only)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get room state",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/http.GetRoomStateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/http.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/http.ErrorResponse"
                         }
@@ -269,7 +327,15 @@
                 }
             }
         },
-        "http.GetAllRoomsStateResponse": {
+        "http.GetRoomResponse": {
+            "type": "object",
+            "properties": {
+                "roomId": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.GetRoomStateResponse": {
             "type": "object",
             "properties": {
                 "clients": {
@@ -279,14 +345,6 @@
                     }
                 },
                 "id": {
-                    "type": "string"
-                }
-            }
-        },
-        "http.GetRoomResponse": {
-            "type": "object",
-            "properties": {
-                "roomId": {
                     "type": "string"
                 }
             }

--- a/planning-poker/internal/infra/boundaries/http/swagger/swagger.yaml
+++ b/planning-poker/internal/infra/boundaries/http/swagger/swagger.yaml
@@ -16,18 +16,18 @@ definitions:
       name:
         type: string
     type: object
-  http.GetAllRoomsStateResponse:
+  http.GetRoomResponse:
+    properties:
+      roomId:
+        type: string
+    type: object
+  http.GetRoomStateResponse:
     properties:
       clients:
         items:
           $ref: '#/definitions/http.GetAllRoomsStateClient'
         type: array
       id:
-        type: string
-    type: object
-  http.GetRoomResponse:
-    properties:
-      roomId:
         type: string
     type: object
   http.HealthStatus:
@@ -73,7 +73,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/http.GetAllRoomsStateResponse'
+              $ref: '#/definitions/http.GetRoomStateResponse'
             type: array
         "401":
           description: Unauthorized
@@ -82,6 +82,43 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Get all rooms state
+      tags:
+      - admin
+  /admin/rooms/{roomID}:
+    get:
+      description: Returns the state of a specific room (admin only)
+      parameters:
+      - description: Room ID
+        in: path
+        name: roomID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/http.GetRoomStateResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/http.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get room state
       tags:
       - admin
   /admin/rooms/{roomID}/client/{clientID}:

--- a/planning-poker/internal/setup/container.go
+++ b/planning-poker/internal/setup/container.go
@@ -109,6 +109,7 @@ func newAPIContainer(cfg *config.Config, infra *InfraContainer, app *Application
 		http.NewGetRoomAPI(infra.Hub),
 		http.NewHealthcheckAPI(healthCheckers...),
 		http.NewGetAllRoomsStateAPI(infra.AdminHub, adminAuthMiddleware),
+		http.NewGetRoomStateAPI(infra.Hub, adminAuthMiddleware),
 		http.NewDisconnectClientAPI(adminRemoveClientUseCase, adminAuthMiddleware),
 		http.NewKickClientAPI(adminKickClientUseCase, adminAuthMiddleware),
 	}


### PR DESCRIPTION
## Summary

Adds a new admin-only endpoint `GET /admin/rooms/{roomID}` that returns the state of a single room, extending the existing `GET /admin/rooms` endpoint with per-room lookup.

## Changes

- **New handler** `GetRoomStateAPI` at `/admin/rooms/{roomID}` with admin auth middleware
- **Reuses existing response shape** — the existing `GetAllRoomsStateResponse` was renamed to `GetRoomStateResponse` for consistency, but keeps the same structure
- **Error handling** — returns `400` for empty roomID, `401` for unauthorized, `404` for unknown room, `500` for unexpected errors
- **Tests** — 9 tests covering success, 404, 401, 400, 500, and context propagation
- **Wired** in `container.go` and swagger regenerated

## Why

Allows admin consumers to query a single room's state without fetching all rooms.