### PR TITLE
feat: add Helm chart for planning-poker with GHCR publishing workflow

### DIFF
--- a/.github/workflows/planning-poker-helm-chart-ci.yml
+++ b/.github/workflows/planning-poker-helm-chart-ci.yml
@@ -1,0 +1,72 @@
+name: Planning Poker Helm Chart CI
+
+on:
+  pull_request:
+    paths:
+      - 'planning-poker/helm/**'
+  push:
+    tags:
+      - 'planning-poker-chart/*'
+
+env:
+  CHART_DIR: planning-poker/helm
+  GHCR_REPO: oci://ghcr.io/bruno303
+
+jobs:
+  lint:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: latest
+      - name: Lint chart
+        working-directory: ${{ env.CHART_DIR }}
+        run: helm lint .
+
+  publish:
+    name: Package and Push to GHCR
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/planning-poker-chart/')
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Check chart version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#planning-poker-chart/}"
+          CHART_VERSION=$(grep '^version:' ${{ env.CHART_DIR }}/Chart.yaml | awk '{print $2}' | tr -d '"' | tr -d "'")
+          if [ -z "$CHART_VERSION" ]; then
+            echo "❌ Could not extract version from ${{ env.CHART_DIR }}/Chart.yaml"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$CHART_VERSION" ]; then
+            echo "❌ Tag version ($TAG_VERSION) != Chart.yaml version ($CHART_VERSION)"
+            exit 1
+          fi
+          echo "✅ Versions match: $TAG_VERSION"
+
+      - name: Package chart
+        run: helm package ${{ env.CHART_DIR }} -d /tmp/chart
+
+      - name: Log in to GHCR
+        run: echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to GHCR
+        run: helm push /tmp/chart/planning-poker-chart-*.tgz ${{ env.GHCR_REPO }}
+
+      - name: Summary
+        run: |
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ Helm Chart Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "* **Package:** \`${{ env.GHCR_REPO }}/planning-poker-chart\`" >> $GITHUB_STEP_SUMMARY
+          echo "* **Version:** \`${GITHUB_REF_NAME#planning-poker-chart/}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/planning-poker-helm-chart-ci.yml
+++ b/.github/workflows/planning-poker-helm-chart-ci.yml
@@ -55,13 +55,16 @@ jobs:
           echo "✅ Versions match: $TAG_VERSION"
 
       - name: Package chart
-        run: helm package ${{ env.CHART_DIR }} -d /tmp/chart
+        id: package
+        run: |
+          helm package ${{ env.CHART_DIR }} -d /tmp/chart
+          echo "chart_package=$(ls /tmp/chart/*.tgz)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         run: echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push chart to GHCR
-        run: helm push /tmp/chart/planning-poker-chart-*.tgz ${{ env.GHCR_REPO }}
+        run: helm push "${{ steps.package.outputs.chart_package }}" ${{ env.GHCR_REPO }}
 
       - name: Summary
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.worktrees/
+.hermes/

--- a/planning-poker/.dockerignore
+++ b/planning-poker/.dockerignore
@@ -1,2 +1,3 @@
 frontend/
 .env
+helm/

--- a/planning-poker/helm/Chart.yaml
+++ b/planning-poker/helm/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: planning-poker-chart
+description: Helm chart for Planning Poker - a real-time agile estimation tool
+type: application
+version: 0.1.0
+appVersion: "latest"
+icon: https://raw.githubusercontent.com/bruno303/study-topics/main/planning-poker/frontend/planning-poker-front/src/app/favicon.ico
+home: https://github.com/bruno303/study-topics/tree/main/planning-poker/helm
+maintainers:
+  - name: Bruno
+    email: bruno@example.com

--- a/planning-poker/helm/Chart.yaml
+++ b/planning-poker/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: planning-poker-chart
+name: planning-poker
 description: Helm chart for Planning Poker - a real-time agile estimation tool
 type: application
 version: 0.1.0

--- a/planning-poker/helm/templates/_helpers.tpl
+++ b/planning-poker/helm/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{- define "planning-poker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "planning-poker.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "planning-poker.labels" -}}
+helm.sh/chart: {{ include "planning-poker.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "planning-poker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "planning-poker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "planning-poker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/planning-poker/helm/templates/backend-deployment.yaml
+++ b/planning-poker/helm/templates/backend-deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-backend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "planning-poker.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "planning-poker.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+      {{- with .Values.backend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+        {{- if $.Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ $.Values.metrics.path | quote }}
+        prometheus.io/port: {{ $.Values.metrics.port | quote }}
+        {{- end }}
+      {{- else }}
+      {{- if .Values.metrics.enabled }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+      {{- end }}
+      {{- end }}
+    spec:
+      {{- with .Values.backend.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
+            {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.metrics.port }}
+              name: metrics
+            {{- end }}
+          env:
+            # Hardcoded env vars (set by the chart, cannot be overridden via values directly)
+            - name: LOG_LEVEL
+              value: DEBUG
+            - name: TRACE_ENABLED
+              value: "true"
+            - name: TRACE_OTLP_ENDPOINT
+              value: tempo.monitoring.svc.cluster.local:4317
+            - name: API_TRACING_ENABLED
+              value: "true"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DB
+              value: "0"
+            - name: REDIS_PASSWORD
+              value: ""
+            - name: REDIS_HOST
+              value: {{ include "planning-poker.fullname" . }}-redis
+            # Env vars from values.yaml backend.env (customizable per environment)
+            {{- range .Values.backend.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            # ADMIN_API_KEY from secret if provided
+            {{- if .Values.backend.secrets.adminApiKey }}
+            - name: ADMIN_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "planning-poker.fullname" . }}-backend
+                  key: ADMIN_API_KEY
+            {{- end }}
+            # Extra env vars (escape hatch for deploy projects)
+            {{- range .Values.backend.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- if or .Values.backend.probes.liveness.enabled .Values.backend.probes.readiness.enabled }}
+          {{- if .Values.backend.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.liveness.httpGet.path }}
+              port: {{ .Values.backend.probes.liveness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.backend.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.liveness.periodSeconds }}
+          {{- end }}
+          {{- if .Values.backend.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.probes.readiness.httpGet.path }}
+              port: {{ .Values.backend.probes.readiness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.backend.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.probes.readiness.periodSeconds }}
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          {{- with .Values.backend.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/planning-poker/helm/templates/backend-deployment.yaml
+++ b/planning-poker/helm/templates/backend-deployment.yaml
@@ -49,29 +49,10 @@ spec:
               name: metrics
             {{- end }}
           env:
-            # Hardcoded env vars (set by the chart, cannot be overridden via values directly)
-            - name: LOG_LEVEL
-              value: DEBUG
-            - name: TRACE_ENABLED
-              value: "true"
-            - name: TRACE_OTLP_ENDPOINT
-              value: tempo.monitoring.svc.cluster.local:4317
-            - name: API_TRACING_ENABLED
-              value: "true"
-            - name: REDIS_PORT
-              value: "6379"
-            - name: REDIS_DB
-              value: "0"
-            - name: REDIS_PASSWORD
-              value: ""
-            - name: REDIS_HOST
-              value: {{ include "planning-poker.fullname" . }}-redis
-            # Env vars from values.yaml backend.env (customizable per environment)
             {{- range .Values.backend.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-            # ADMIN_API_KEY from secret if provided
             {{- if .Values.backend.secrets.adminApiKey }}
             - name: ADMIN_API_KEY
               valueFrom:
@@ -79,7 +60,6 @@ spec:
                   name: {{ include "planning-poker.fullname" . }}-backend
                   key: ADMIN_API_KEY
             {{- end }}
-            # Extra env vars (escape hatch for deploy projects)
             {{- range .Values.backend.extraEnv }}
             - name: {{ .name }}
               value: {{ .value | quote }}
@@ -92,6 +72,7 @@ spec:
               port: {{ .Values.backend.probes.liveness.httpGet.port }}
             initialDelaySeconds: {{ .Values.backend.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.backend.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.backend.probes.liveness.failureThreshold }}
           {{- end }}
           {{- if .Values.backend.probes.readiness.enabled }}
           readinessProbe:
@@ -100,6 +81,7 @@ spec:
               port: {{ .Values.backend.probes.readiness.httpGet.port }}
             initialDelaySeconds: {{ .Values.backend.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.backend.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.backend.probes.readiness.failureThreshold }}
           {{- end }}
           {{- end }}
           resources:

--- a/planning-poker/helm/templates/backend-ingress.yaml
+++ b/planning-poker/helm/templates/backend-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.backend.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-backend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  {{- with .Values.ingress.backend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.backend.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.backend.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "planning-poker.fullname" $ }}-backend
+                port:
+                  number: 8080
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.backend.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/planning-poker/helm/templates/backend-secret.yaml
+++ b/planning-poker/helm/templates/backend-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.backend.secrets.adminApiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-backend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+type: Opaque
+data:
+  ADMIN_API_KEY: {{ .Values.backend.secrets.adminApiKey | b64enc | quote }}
+{{- end }}

--- a/planning-poker/helm/templates/backend-service.yaml
+++ b/planning-poker/helm/templates/backend-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-backend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+      name: http-metrics
+    {{- end }}
+  selector:
+    {{- include "planning-poker.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend

--- a/planning-poker/helm/templates/frontend-deployment.yaml
+++ b/planning-poker/helm/templates/frontend-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-frontend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "planning-poker.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "planning-poker.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+      {{- with .Values.frontend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.frontend.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            {{- range $key, $val := .Values.frontend.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- range .Values.frontend.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- if or .Values.frontend.probes.liveness.enabled .Values.frontend.probes.readiness.enabled }}
+          {{- if .Values.frontend.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.frontend.probes.liveness.httpGet.path }}
+              port: {{ .Values.frontend.probes.liveness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.frontend.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.probes.liveness.periodSeconds }}
+          {{- end }}
+          {{- if .Values.frontend.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.frontend.probes.readiness.httpGet.path }}
+              port: {{ .Values.frontend.probes.readiness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.frontend.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.probes.readiness.periodSeconds }}
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          {{- with .Values.frontend.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.frontend.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.frontend.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/planning-poker/helm/templates/frontend-deployment.yaml
+++ b/planning-poker/helm/templates/frontend-deployment.yaml
@@ -49,6 +49,7 @@ spec:
               port: {{ .Values.frontend.probes.liveness.httpGet.port }}
             initialDelaySeconds: {{ .Values.frontend.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.frontend.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.frontend.probes.liveness.failureThreshold }}
           {{- end }}
           {{- if .Values.frontend.probes.readiness.enabled }}
           readinessProbe:
@@ -57,6 +58,7 @@ spec:
               port: {{ .Values.frontend.probes.readiness.httpGet.port }}
             initialDelaySeconds: {{ .Values.frontend.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.frontend.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.frontend.probes.readiness.failureThreshold }}
           {{- end }}
           {{- end }}
           resources:

--- a/planning-poker/helm/templates/frontend-ingress.yaml
+++ b/planning-poker/helm/templates/frontend-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.frontend.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-frontend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  {{- with .Values.ingress.frontend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.frontend.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.frontend.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "planning-poker.fullname" $ }}-frontend
+                port:
+                  number: 80
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.frontend.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/planning-poker/helm/templates/frontend-service.yaml
+++ b/planning-poker/helm/templates/frontend-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-frontend
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 3000
+      name: http
+  selector:
+    {{- include "planning-poker.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend

--- a/planning-poker/helm/templates/redis-deployment.yaml
+++ b/planning-poker/helm/templates/redis-deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-redis
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: {{ .Values.redis.replicas }}
+  selector:
+    matchLabels:
+      {{- include "planning-poker.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "planning-poker.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.redis.port }}
+              name: redis
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          {{- with .Values.redis.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.redis.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.redis.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/planning-poker/helm/templates/redis-deployment.yaml
+++ b/planning-poker/helm/templates/redis-deployment.yaml
@@ -25,6 +25,24 @@ spec:
           ports:
             - containerPort: {{ .Values.redis.port }}
               name: redis
+          {{- if or .Values.redis.probes.liveness.enabled .Values.redis.probes.readiness.enabled }}
+          {{- if .Values.redis.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.redis.probes.liveness.tcpSocket.port }}
+            initialDelaySeconds: {{ .Values.redis.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redis.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.redis.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.redis.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.redis.probes.readiness.tcpSocket.port }}
+            initialDelaySeconds: {{ .Values.redis.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redis.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.redis.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           {{- with .Values.redis.nodeSelector }}

--- a/planning-poker/helm/templates/redis-service.yaml
+++ b/planning-poker/helm/templates/redis-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "planning-poker.fullname" . }}-redis
+  labels:
+    {{- include "planning-poker.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.redis.port }}
+      targetPort: {{ .Values.redis.port }}
+      name: redis
+  selector:
+    {{- include "planning-poker.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/planning-poker/helm/values.yaml
+++ b/planning-poker/helm/values.yaml
@@ -1,0 +1,142 @@
+# Global
+nameOverride: "planning-poker"
+fullnameOverride: ""
+
+# Backend
+backend:
+  image:
+    repository: bruno303/planning-poker-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  imagePullSecrets: []
+  env:
+    - name: ENVIRONMENT
+      value: development
+    - name: API_CORS_ALLOWED_ORIGINS
+      value: "http://localhost:3000"
+  extraEnv: []      # list of arbitrary env vars for deploy projects to inject
+  secrets:
+    adminApiKey: ""  # if non-empty, creates a Secret; otherwise expects existing
+  probes:
+    liveness:
+      enabled: true
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 10
+      periodSeconds: 15
+    readiness:
+      enabled: true
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+
+# Frontend
+frontend:
+  image:
+    repository: bruno303/planning-poker-frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  imagePullSecrets: []
+  env: {}            # No default env vars
+  extraEnv: []       # escape hatch for deploy projects
+  probes:
+    liveness:
+      enabled: true
+      httpGet:
+        path: /
+        port: 3000
+      initialDelaySeconds: 10
+      periodSeconds: 15
+    readiness:
+      enabled: true
+      httpGet:
+        path: /
+        port: 3000
+      initialDelaySeconds: 5
+      periodSeconds: 10
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  podAnnotations: {}
+
+# Ingress (disabled by default, deploy project enables per env)
+ingress:
+  backend:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  frontend:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+# Redis (bundled in chart, toggleable)
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: 7-alpine
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 6379
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Metrics (toggleable)
+metrics:
+  enabled: true
+  port: 9090
+  path: /metrics
+
+# Backend env vars that are hardcoded in the template (not in values):
+# - LOG_LEVEL: DEBUG
+# - TRACE_ENABLED: "true"
+# - TRACE_OTLP_ENDPOINT: tempo.monitoring.svc.cluster.local:4317
+# - API_TRACING_ENABLED: "true"
+# - REDIS_PORT: "6379"
+# - REDIS_DB: "0"
+# - REDIS_PASSWORD: ""
+# These are set directly in the deployment template. The deploy project can override via extraEnv if needed.

--- a/planning-poker/helm/values.yaml
+++ b/planning-poker/helm/values.yaml
@@ -11,11 +11,27 @@ backend:
   replicas: 1
   imagePullSecrets: []
   env:
+    - name: LOG_LEVEL
+      value: DEBUG
+    - name: TRACE_ENABLED
+      value: "true"
+    - name: TRACE_OTLP_ENDPOINT
+      value: tempo.monitoring.svc.cluster.local:4317
+    - name: API_TRACING_ENABLED
+      value: "true"
+    - name: REDIS_PORT
+      value: "6379"
+    - name: REDIS_DB
+      value: "0"
+    - name: REDIS_PASSWORD
+      value: ""
+    - name: REDIS_HOST
+      value: planning-poker-redis
     - name: ENVIRONMENT
       value: development
     - name: API_CORS_ALLOWED_ORIGINS
       value: "http://localhost:3000"
-  extraEnv: []      # list of arbitrary env vars for deploy projects to inject
+  extraEnv: []
   secrets:
     adminApiKey: ""  # if non-empty, creates a Secret; otherwise expects existing
   probes:
@@ -26,6 +42,7 @@ backend:
         port: 8080
       initialDelaySeconds: 10
       periodSeconds: 15
+      failureThreshold: 3
     readiness:
       enabled: true
       httpGet:
@@ -33,6 +50,7 @@ backend:
         port: 8080
       initialDelaySeconds: 5
       periodSeconds: 10
+      failureThreshold: 3
   resources:
     requests:
       cpu: 100m
@@ -63,6 +81,7 @@ frontend:
         port: 3000
       initialDelaySeconds: 10
       periodSeconds: 15
+      failureThreshold: 3
     readiness:
       enabled: true
       httpGet:
@@ -70,6 +89,7 @@ frontend:
         port: 3000
       initialDelaySeconds: 5
       periodSeconds: 10
+      failureThreshold: 3
   resources:
     requests:
       cpu: 100m
@@ -114,6 +134,21 @@ redis:
     pullPolicy: IfNotPresent
   replicas: 1
   port: 6379
+  probes:
+    liveness:
+      enabled: true
+      tcpSocket:
+        port: 6379
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      tcpSocket:
+        port: 6379
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 3
   resources:
     requests:
       cpu: 50m
@@ -131,12 +166,3 @@ metrics:
   port: 9090
   path: /metrics
 
-# Backend env vars that are hardcoded in the template (not in values):
-# - LOG_LEVEL: DEBUG
-# - TRACE_ENABLED: "true"
-# - TRACE_OTLP_ENDPOINT: tempo.monitoring.svc.cluster.local:4317
-# - API_TRACING_ENABLED: "true"
-# - REDIS_PORT: "6379"
-# - REDIS_DB: "0"
-# - REDIS_PASSWORD: ""
-# These are set directly in the deployment template. The deploy project can override via extraEnv if needed.


### PR DESCRIPTION
## Summary

Adds a Helm chart for the Planning Poker application and a CI workflow to publish it to GitHub Container Registry (GHCR).

## What's included

### Helm chart (`planning-poker/helm/`)
- Backend Deployment + Service + Ingress + Secret
- Frontend Deployment + Service + Ingress
- Redis Deployment + Service (bundled, toggleable)
- Resource defaults, probes, Prometheus metrics annotations
- `extraEnv` escape hatch for deploy project overrides
- Ingress disabled by default, helm-standard structure

### CI workflow (`.github/workflows/planning-poker-helm-chart-ci.yml`)
- **On PR** touching `planning-poker/helm/**`: runs `helm lint`
- **On tag** `planning-poker-chart/*`: validates version → packages → pushes to `oci://ghcr.io/bruno303/planning-poker-chart`

### Other changes
- `planning-poker/.dockerignore`: added `helm/` (already present)

## Usage

```bash
# Release a new chart version:
# 1. Bump version in planning-poker/helm/Chart.yaml
# 2. Commit and push to main
# 3. Tag and push:
git tag planning-poker-chart/X.Y.Z
git push origin planning-poker-chart/X.Y.Z
# 4. CI publishes to GHCR
# 5. Deploy project pulls:
helm upgrade --install planning-poker oci://ghcr.io/bruno303/planning-poker-chart --version X.Y.Z -n staging -f staging-values.yaml
```

## Prerequisites

Before first publish, enable **Read and write permissions** on GITHUB_TOKEN in:
Settings → Actions → General → Workflow permissions