### PR TITLE
fix(ci): enable SonarQube PR decoration with deep checkout and quality gate

### DIFF
--- a/.github/workflows/planning-poker-ci.yml
+++ b/.github/workflows/planning-poker-ci.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -73,6 +75,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: ${{ env.APP_DIR }}
+
+      - name: SonarQube Quality Gate
+        uses: SonarSource/sonarqube-quality-gate-action@v2
+        with:
+          scanMetadataReportFile: ${{ env.APP_DIR }}/.scannerwork/report-task.txt
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

Two fixes to make SonarQube actually decorate pull requests:

### 1. Deep checkout (fetch-depth: 0)
The `tests-and-coverage` job's checkout was shallow. SonarQube needs full git history to properly analyze changes and link them to the PR.

### 2. Quality Gate check
Added `SonarSource/sonarqube-quality-gate-action@v2` after the scan so the PR is flagged when the Quality Gate fails.

## Still needed (outside this PR)

**3. Install the SonarCloud GitHub App**
This is the root cause of missing PR comments. The scanner only sends analysis data — PR decoration is done by the [SonarCloud GitHub App](https://github.com/marketplace/sonarcloud). It must be installed and granted access to this repository. Without it, no comments or flags will appear on PRs regardless of workflow changes.