### PR TITLE
feat(k8s): manage secrets via External Secrets Operator + Doppler

### DIFF
--- a/self_hosted/.gitignore
+++ b/self_hosted/.gitignore
@@ -1,3 +1,4 @@
 .env
 data/
 *.code-workspace
+charts/

--- a/self_hosted/k8s/argo/apps/eso.yaml
+++ b/self_hosted/k8s/argo/apps/eso.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: eso
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/bruno303/study-topics
+    targetRevision: HEAD
+    path: self_hosted/k8s/eso
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: eso
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/self_hosted/k8s/cloudflared/externalsecret.yaml
+++ b/self_hosted/k8s/cloudflared/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-tunnel-secret
+  namespace: cloudflare
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-prd
+    kind: ClusterSecretStore
+  target:
+    name: cloudflare-tunnel-secret
+  data:
+    - secretKey: token
+      remoteRef:
+        key: CLOUDFLARE_TUNNEL_TOKEN

--- a/self_hosted/k8s/eso/kustomization.yaml
+++ b/self_hosted/k8s/eso/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: external-secrets
+    repo: https://charts.external-secrets.io
+    version: 2.9.0
+    releaseName: external-secrets
+    namespace: eso
+    valuesFile: values.yaml
+resources:
+  - secret-store-prd.yaml
+  - secret-store-stg.yaml
+  - ntfy-externalsecret.yaml

--- a/self_hosted/k8s/eso/ntfy-externalsecret.yaml
+++ b/self_hosted/k8s/eso/ntfy-externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ntfy
+  namespace: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-prd
+    kind: ClusterSecretStore
+  target:
+    name: ntfy
+  data:
+    - secretKey: NTFY_AUTH_USERS
+      remoteRef:
+        key: NTFY_AUTH_USERS

--- a/self_hosted/k8s/eso/secret-store-prd.yaml
+++ b/self_hosted/k8s/eso/secret-store-prd.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: doppler-prd
+spec:
+  provider:
+    doppler:
+      project: homelab
+      config: prd
+      auth:
+        secretRef:
+          dopplerToken:
+            name: doppler-token
+            namespace: eso
+            key: token

--- a/self_hosted/k8s/eso/secret-store-stg.yaml
+++ b/self_hosted/k8s/eso/secret-store-stg.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: doppler-stg
+spec:
+  provider:
+    doppler:
+      project: homelab
+      config: stg
+      auth:
+        secretRef:
+          dopplerToken:
+            name: doppler-token-stg
+            namespace: eso
+            key: token

--- a/self_hosted/k8s/eso/values.yaml
+++ b/self_hosted/k8s/eso/values.yaml
@@ -1,0 +1,7 @@
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 192Mi

--- a/self_hosted/k8s/gitea/externalsecret.yaml
+++ b/self_hosted/k8s/gitea/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitea
+  namespace: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-prd
+    kind: ClusterSecretStore
+  target:
+    name: gitea
+  data:
+    - secretKey: GITEA_RUNNER_REGISTRATION_TOKEN
+      remoteRef:
+        key: GITEA_RUNNER_REGISTRATION_TOKEN

--- a/self_hosted/k8s/observability/grafana/externalsecret.yaml
+++ b/self_hosted/k8s/observability/grafana/externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-prd
+    kind: ClusterSecretStore
+  target:
+    name: grafana-admin
+  data:
+    - secretKey: admin-user
+      remoteRef:
+        key: GRAFANA_ADMIN_USER
+    - secretKey: admin-password
+      remoteRef:
+        key: GRAFANA_ADMIN_PASSWORD

--- a/self_hosted/k8s/observability/grafana/kustomization.yaml
+++ b/self_hosted/k8s/observability/grafana/kustomization.yaml
@@ -10,3 +10,4 @@ helmCharts:
 resources:
   - pv.yaml
   - ingress.yaml
+  - externalsecret.yaml

--- a/self_hosted/k8s/pdfding/externalsecret.yaml
+++ b/self_hosted/k8s/pdfding/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pdfding-secret
+  namespace: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-prd
+    kind: ClusterSecretStore
+  target:
+    name: pdfding-secret
+  data:
+    - secretKey: SECRET_KEY
+      remoteRef:
+        key: PDFDING_SECRET_KEY

--- a/self_hosted/k8s/planning-poker/production/backend/externalsecret.yaml
+++ b/self_hosted/k8s/planning-poker/production/backend/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: planning-poker-backend
+  namespace: production
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-prd
+    kind: ClusterSecretStore
+  target:
+    name: planning-poker-backend
+  data:
+    - secretKey: ADMIN_API_KEY
+      remoteRef:
+        key: PLANNING_POKER_ADMIN_API_KEY

--- a/self_hosted/k8s/planning-poker/staging/backend/externalsecret.yaml
+++ b/self_hosted/k8s/planning-poker/staging/backend/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: planning-poker-backend
+  namespace: staging
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: doppler-stg
+    kind: ClusterSecretStore
+  target:
+    name: planning-poker-backend
+  data:
+    - secretKey: ADMIN_API_KEY
+      remoteRef:
+        key: PLANNING_POKER_ADMIN_API_KEY


### PR DESCRIPTION
## What

Introduces GitOps-managed secrets using [External Secrets Operator](https://external-secrets.io) with Doppler as the external provider, so secrets survive cluster migration and are no longer hand-applied.

## Changes

- **`k8s/eso/`** (new): external-secrets helm chart (v2.9.0) + two `ClusterSecretStore`s:
  - `doppler-prd` → project `homelab`, config `prd`, token from secret `doppler-token`/ns `eso`
  - `doppler-stg` → project `homelab`, config `stg`, token from secret `doppler-token-stg`/ns `eso`
  - Resources tuned for a low-spec machine (50m/64Mi requests)
- **`k8s/argo/apps/eso.yaml`** (new): ArgoCD Application (selfHeal + prune)
- **ExternalSecrets** (one per service, in each service's folder):
  | Secret | Keys (Doppler ← k8s) | Store |
  |---|---|---|
  | `pdfding-secret` | `PDFDING_SECRET_KEY` → `SECRET_KEY` | prd |
  | `gitea` | `GITEA_RUNNER_REGISTRATION_TOKEN` | prd |
  | `cloudflare-tunnel-secret` | `CLOUDFLARE_TUNNEL_TOKEN` → `token` | prd |
  | `grafana-admin` | `GRAFANA_ADMIN_USER` → `admin-user`, `GRAFANA_ADMIN_PASSWORD` → `admin-password` | prd |
  | `planning-poker-backend` (production) | `PLANNING_POKER_ADMIN_API_KEY` → `ADMIN_API_KEY` | prd |
  | `planning-poker-backend` (staging) | `PLANNING_POKER_ADMIN_API_KEY` → `ADMIN_API_KEY` | stg |
  | `ntfy` (in `k8s/eso/` since ntfy has no ArgoCD app) | `NTFY_AUTH_USERS` | prd |
- **`self_hosted/.gitignore`**: ignore downloaded `charts/` dirs from local kustomize renders

## Manual bootstrap (already done)

The Doppler service tokens exist as secrets `doppler-token` and `doppler-token-stg` in the `eso` namespace (created with kubectl, never committed).

## Follow-up after merge

1. ArgoCD deploys ESO + stores → verify all ExternalSecrets report `Synced`
2. Compare current `grafana-admin` password with Doppler value (should be identical → no disruption)
3. Delete old manually-created secrets → ESO recreates identical ones