### PR TITLE
fix(k8s): use server-side apply for ESO app

### DIFF
--- a/self_hosted/k8s/argo/apps/eso.yaml
+++ b/self_hosted/k8s/argo/apps/eso.yaml
@@ -18,3 +18,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Problem

The ESO deployment is broken: `secretstores` and `clustersecretstores` CRDs failed to install, keeping the app OutOfSync and the controller crash-looping.

**Root cause:** the ESO v2.9 CRDs contain all provider schemas and are so large that client-side apply (which adds the `kubectl.kubernetes.io/last-applied-configuration` annotation) exceeds the 262KB annotation limit:

```
The CustomResourceDefinition "secretstores.external-secrets.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

Verified: server-side apply succeeds on the same CRDs (dry-run), and ArgoCD is v3.4.4 which fully supports SSA.

## Fix

Add `ServerSideApply=true` sync option to the `eso` Application. SSA doesn't write the oversized annotation, so the CRDs install cleanly. Scoped to the eso app only — no other apps are affected.

After merge, ArgoCD will sync the CRDs and ClusterSecretStores automatically.