### PR TITLE
fix(k8s): use external-secrets.io/v1 API for ESO resources

### DIFF
--- a/self_hosted/k8s/cloudflared/externalsecret.yaml
+++ b/self_hosted/k8s/cloudflared/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-tunnel-secret

--- a/self_hosted/k8s/eso/ntfy-externalsecret.yaml
+++ b/self_hosted/k8s/eso/ntfy-externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: ntfy

--- a/self_hosted/k8s/eso/secret-store-prd.yaml
+++ b/self_hosted/k8s/eso/secret-store-prd.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: doppler-prd

--- a/self_hosted/k8s/eso/secret-store-stg.yaml
+++ b/self_hosted/k8s/eso/secret-store-stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: doppler-stg

--- a/self_hosted/k8s/gitea/externalsecret.yaml
+++ b/self_hosted/k8s/gitea/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gitea

--- a/self_hosted/k8s/observability/grafana/externalsecret.yaml
+++ b/self_hosted/k8s/observability/grafana/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana-admin

--- a/self_hosted/k8s/pdfding/externalsecret.yaml
+++ b/self_hosted/k8s/pdfding/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: pdfding-secret

--- a/self_hosted/k8s/planning-poker/production/backend/externalsecret.yaml
+++ b/self_hosted/k8s/planning-poker/production/backend/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: planning-poker-backend

--- a/self_hosted/k8s/planning-poker/staging/backend/externalsecret.yaml
+++ b/self_hosted/k8s/planning-poker/staging/backend/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: planning-poker-backend


### PR DESCRIPTION
## Problem

ClusterSecretStores and ExternalSecrets fail to sync:

```
The Kubernetes API could not find version "v1beta1" of external-secrets.io/ClusterSecretStore.
Version "v1" is installed on the destination cluster.
```

ESO v2.9 CRDs serve only `v1` (`v1beta1` is present but `served=false`).

## Fix

Updated all 9 manifests (`ClusterSecretStore` x2, `ExternalSecret` x7) from `external-secrets.io/v1beta1` to `external-secrets.io/v1`.

After merge, ArgoCD syncs the stores and ExternalSecrets.