### PR TITLE
fix(k8s): otel-collector-agent positions dir permission

### DIFF
--- a/self_hosted/k8s/observability/otel-collector/daemonset.yaml
+++ b/self_hosted/k8s/observability/otel-collector/daemonset.yaml
@@ -22,6 +22,19 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+      initContainers:
+        # Prepare the hostPath positions dir (root-owned) for the non-root collector (UID 10001)
+        - name: init-positions
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - mkdir -p /var/lib/otel-collector/positions && chown -R 10001:10001 /var/lib/otel-collector/positions
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: positions
+              mountPath: /var/lib/otel-collector/positions
       containers:
         - name: otel-collector-agent
           image: otel/opentelemetry-collector-contrib:0.158.0


### PR DESCRIPTION
Fixes the otel-collector-agent CrashLoopBackOff:\n\n`storage client: open /var/lib/otel-collector/positions/receiver_filelog_: permission denied`\n\nThe otel-collector-contrib image runs as UID 10001 but the hostPath positions directory is root-owned, so the filelog receiver cannot write its offsets.\n\nAdd a root initContainer that creates and chowns the directory before the collector starts (the collector itself stays non-root).