### PR TITLE
fix(k8s): silence otel-collector-agent move errors on non-JSON logs

### DIFF
--- a/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
+++ b/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
@@ -84,9 +84,11 @@ data:
           - type: move
             from: attributes.level
             to: resource["log_level"]
+            if: 'attributes.level != nil'
           - type: move
             from: attributes.message
             to: body
+            if: 'attributes.message != nil'
           - type: move
             from: attributes["log.iostream"]
             to: resource["stream"]


### PR DESCRIPTION
During live validation, the agent logged ~1200 `Failed to process entry` errors per minute while backfilling. The `attributes.level -> resource[log_level]` and `attributes.message -> body` moves fail for every non-JSON log line (plain text logs, the agent's own stack traces), because those attributes don't exist.\n\nGuard both moves with `if: '... != nil'` so non-JSON entries pass through silently. JSON logs with `level`/`message` fields behave exactly as before (log_level label + cleaned body).