### PR TITLE
fix(k8s): raise loki memory limit to survive WAL replay

### DIFF
--- a/self_hosted/k8s/observability/loki/deployment.yaml
+++ b/self_hosted/k8s/observability/loki/deployment.yaml
@@ -24,10 +24,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "128Mi"
-          limits:
-            cpu: "200m"
             memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "1Gi"
         volumeMounts:
         - name: loki-data
           mountPath: /tmp/loki

--- a/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
+++ b/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
@@ -84,9 +84,11 @@ data:
           - type: move
             from: attributes.level
             to: resource["log_level"]
+            if: 'attributes.level != nil'
           - type: move
             from: attributes.message
             to: body
+            if: 'attributes.message != nil'
           - type: move
             from: attributes["log.iostream"]
             to: resource["stream"]


### PR DESCRIPTION
Loki is crash-looping with exit code 137 (OOMKilled) during WAL recovery.\n\nAfter the observability migration, the agent backfilled a large volume of historical logs, growing Loki's WAL. WAL replay now takes ~30s and peaks above the 256Mi container limit, so Loki gets OOM-killed right after startup — every restart.\n\nBump memory: requests 128Mi -> 256Mi, limits 256Mi -> 1Gi (host has 13Gi free). Once the WAL flushes normally the replay will shrink back.