### PR TITLE
fix(k8s): raise loki memory limit to 2Gi

### DIFF
--- a/self_hosted/k8s/observability/loki/deployment.yaml
+++ b/self_hosted/k8s/observability/loki/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             memory: "256Mi"
           limits:
             cpu: "500m"
-            memory: "1Gi"
+            memory: "2Gi"
         volumeMounts:
         - name: loki-data
           mountPath: /tmp/loki

--- a/self_hosted/k8s/observability/loki/deployment.yaml
+++ b/self_hosted/k8s/observability/loki/deployment.yaml
@@ -24,10 +24,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "128Mi"
-          limits:
-            cpu: "200m"
             memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "1Gi"
         volumeMounts:
         - name: loki-data
           mountPath: /tmp/loki

--- a/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
+++ b/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
@@ -84,9 +84,11 @@ data:
           - type: move
             from: attributes.level
             to: resource["log_level"]
+            if: 'attributes.level != nil'
           - type: move
             from: attributes.message
             to: body
+            if: 'attributes.message != nil'
           - type: move
             from: attributes["log.iostream"]
             to: resource["stream"]


### PR DESCRIPTION
1Gi was still too tight. The pod is OOMKilled (now surfacing as `OOMKilled` status) despite working_set ~488Mi, because the cgroup OOM basis is `container_memory_usage_bytes` which includes page cache — it hovers at 800-880Mi of the 1Gi limit, so any transient spike during WAL replay/flush trips the OOM killer.\n\nThe WAL is bloated from the log backfill; once it drains and flushes normally, replay memory will shrink. 2Gi gives headroom in the meantime (host has 13Gi free).