### PR TITLE
fix(k8s): stop otel-collector-agent log backfill

### DIFF
--- a/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
+++ b/self_hosted/k8s/observability/otel-collector/configmap-agent.yaml
@@ -5,18 +5,13 @@ metadata:
   namespace: monitoring
 data:
   otel-collector.yaml: |
-    extensions:
-      file_storage:
-        directory: /var/lib/otel-collector/positions
-        create_directory: true
     receivers:
       filelog:
         include:
           - /var/log/pods/*/*/*.log
-        start_at: beginning
+        start_at: end
         include_file_path: true
         include_file_name: false
-        storage: file_storage
         operators:
           - type: router
             id: get-format
@@ -140,7 +135,6 @@ data:
         tls:
           insecure: true
     service:
-      extensions: [file_storage]
       pipelines:
         logs:
           receivers: [filelog]

--- a/self_hosted/k8s/observability/otel-collector/daemonset.yaml
+++ b/self_hosted/k8s/observability/otel-collector/daemonset.yaml
@@ -22,19 +22,6 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
-      initContainers:
-        # Prepare the hostPath positions dir (root-owned) for the non-root collector (UID 10001)
-        - name: init-positions
-          image: busybox:1.36
-          command:
-            - sh
-            - -c
-            - mkdir -p /var/lib/otel-collector/positions && chown -R 10001:10001 /var/lib/otel-collector/positions
-          securityContext:
-            runAsUser: 0
-          volumeMounts:
-            - name: positions
-              mountPath: /var/lib/otel-collector/positions
       containers:
         - name: otel-collector-agent
           image: otel/opentelemetry-collector-contrib:0.158.0
@@ -46,8 +33,6 @@ spec:
             - name: varlogpods
               mountPath: /var/log/pods
               readOnly: true
-            - name: positions
-              mountPath: /var/lib/otel-collector/positions
           resources:
             requests:
               cpu: "100m"
@@ -62,7 +47,3 @@ spec:
         - name: varlogpods
           hostPath:
             path: /var/log/pods
-        - name: positions
-          hostPath:
-            path: /var/lib/otel-collector/positions
-            type: DirectoryOrCreate


### PR DESCRIPTION
The agent's filelog receiver used `start_at: beginning`, replaying weeks of historical pod logs into Loki. That backfill is what bloated Loki's WAL and drove the OOM crash-loop.\n\nChanges:\n- `start_at: end` — only new log lines are collected from now on\n- drop the `file_storage` extension and positions hostPath (with `start_at: end` a restart starts at the current end of each file, so persisted offsets add nothing)\n- remove the `init-positions` initContainer (no longer needed — also resolves the non-root permission issue from #146)\n\nNote: Loki's already-accepted backfill data stays; the WAL drains once it stabilizes (2Gi limit from #149).